### PR TITLE
Feat: 간단한 적 AI구현, 카메라 이동 구현

### DIFF
--- a/Noname_Project/Assets/Player/Animation/PlayerAnimator.controller
+++ b/Noname_Project/Assets/Player/Animation/PlayerAnimator.controller
@@ -224,19 +224,19 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Jump
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Noname_Project/Assets/Scenes/SampleScene.unity
+++ b/Noname_Project/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,37 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &199295571
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 199295572}
+  m_Layer: 0
+  m_Name: Melee2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &199295572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 199295571}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.82, y: 0.01, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1030833800}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &310900368
 GameObject:
   m_ObjectHideFlags: 0
@@ -264,6 +295,8 @@ GameObject:
   - component: {fileID: 519420032}
   - component: {fileID: 519420031}
   - component: {fileID: 519420029}
+  - component: {fileID: 519420033}
+  - component: {fileID: 519420034}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -314,7 +347,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 6
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -338,13 +371,221 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &519420033
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee78537d7236a1b4e827cb0476187d16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 1030833800}
+  center: {x: 0, y: 0}
+  size: {x: 30, y: 10}
+--- !u!114 &519420034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a160d838ff8b4b4693ac20007e008c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AssetsPPU: 90
+  m_RefResolutionX: 1920
+  m_RefResolutionY: 1080
+  m_UpscaleRT: 0
+  m_PixelSnapping: 0
+  m_CropFrameX: 0
+  m_CropFrameY: 0
+  m_StretchFill: 1
+--- !u!1 &549275358
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 549275362}
+  - component: {fileID: 549275361}
+  - component: {fileID: 549275360}
+  - component: {fileID: 549275359}
+  - component: {fileID: 549275363}
+  m_Layer: 0
+  m_Name: Square (1)
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!50 &549275359
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549275358}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!61 &549275360
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549275358}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &549275361
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549275358}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0.5943396, g: 0.075694196, b: 0.075694196, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &549275362
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549275358}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.83, y: -1.66, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &549275363
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549275358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5332cfeee34fe894cb9423c9e4372a8e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HP: 3
+  nextMove: 0
 --- !u!1 &1030833798
 GameObject:
   m_ObjectHideFlags: 0
@@ -433,6 +674,7 @@ Transform:
   m_Children:
   - {fileID: 2123150876}
   - {fileID: 1855080523}
+  - {fileID: 199295572}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &1030833801
@@ -532,17 +774,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inputVec: {x: 0, y: 0}
   Maxspeed: 3
-  jumpTime: 0.3
-  JumpPower: 5
+  jumpTime: 0.5
+  JumpPower: 7
   fallMultiplier: 1.5
-  jumpMultiplier: 0.5
+  jumpMultiplier: 1
   groundCheck: {fileID: 2123150876}
   groundLayer:
     serializedVersion: 2
     m_Bits: 64
-  coolTime: 0.5
+  coolTime: 1
   curTime: 0
   pos: {fileID: 1855080523}
+  pos2: {fileID: 199295572}
   boxSize: {x: 0.75, y: 1.36}
 --- !u!1 &1855080522
 GameObject:
@@ -613,3 +856,4 @@ SceneRoots:
   - {fileID: 519420032}
   - {fileID: 1030833800}
   - {fileID: 310900370}
+  - {fileID: 549275362}

--- a/Noname_Project/Assets/Scripts/CameraControler.cs
+++ b/Noname_Project/Assets/Scripts/CameraControler.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CameraControler : MonoBehaviour
+{
+    public Transform target;
+ 
+
+    public Vector2 center;
+    public Vector2 size;
+    float height;
+    float width;
+
+    void Start()
+    {
+        height = Camera.main.orthographicSize;
+        width = height * Screen.width / Screen.height;
+    }
+
+    private void OnDrawGizmos()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireCube(center, size);
+    }
+
+    void LateUpdate()
+    {
+        transform.position = new Vector3(target.position.x, target.position.y, - 10f);
+        //transform.position = Vector3.Lerp(transform.position, target.position, Time.deltaTime);
+    
+        float lx = size.x * 0.5f - width; 
+        float clampX = Mathf.Clamp(transform.position.x, -lx + center.x, lx + center.x);
+
+        float ly = size.y * 0.5f - height;
+        float clampY = Mathf.Clamp(transform.position.y, -ly + center.y, ly + center.y);
+
+        transform.position = new Vector3(clampX, clampY, -10f);
+    }
+}

--- a/Noname_Project/Assets/Scripts/CameraControler.cs.meta
+++ b/Noname_Project/Assets/Scripts/CameraControler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee78537d7236a1b4e827cb0476187d16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Noname_Project/Assets/Scripts/Enemy.cs
+++ b/Noname_Project/Assets/Scripts/Enemy.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Enemy : MonoBehaviour
+{
+    public int HP = 3;
+    public int nextMove;    // 1:right -1:left
+
+    Rigidbody2D rb;
+    Animator anim;
+    SpriteRenderer spriter;
+
+    void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        anim = GetComponent<Animator>();
+        spriter = GetComponent<SpriteRenderer>();
+
+        MoveRandom();
+    }
+
+    void FixedUpdate()
+    {
+        rb.velocity = new Vector2(nextMove, rb.velocity.y);
+
+        Vector2 frontVec = new Vector2(rb.position.x + nextMove * 0.5f, rb.position.y);
+        Debug.DrawLine(frontVec, Vector3.down, new Color(0, 1, 0));
+        RaycastHit2D rayHit = Physics2D.Raycast(frontVec, Vector3.down, 1, LayerMask.GetMask("Ground"));
+        if (rayHit.collider == null)
+            Turn();         
+    }
+
+    void MoveRandom()
+    {
+        nextMove = Random.Range(-1, 2);
+
+        //anim.SetInteger("WalkSpeed", nextMove);
+        if(nextMove != 0)
+        {
+            spriter.flipX = nextMove < 0;
+        }
+
+        float nextTime = Random.Range(2f, 7f);
+        Invoke("MoveRandom", nextTime);
+    }
+
+    void Turn()
+    {
+        nextMove *= -1;
+        spriter.flipX = nextMove < 0;
+
+        CancelInvoke();
+        Invoke("MoveRandom", 3);
+    }
+
+    public void TakeDamage(int damage)
+    {
+        HP = HP - damage; 
+    }
+}

--- a/Noname_Project/Assets/Scripts/Enemy.cs.meta
+++ b/Noname_Project/Assets/Scripts/Enemy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5332cfeee34fe894cb9423c9e4372a8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Noname_Project/Assets/Scripts/PlayerControler.cs
+++ b/Noname_Project/Assets/Scripts/PlayerControler.cs
@@ -23,6 +23,7 @@ public class PlayerControler : MonoBehaviour
     [SerializeField] public float coolTime = 0.5f;
     [SerializeField] public float curTime;
     public Transform pos;
+    public Transform pos2;
     public Vector2 boxSize;
 
     Rigidbody2D rb;
@@ -47,71 +48,8 @@ public class PlayerControler : MonoBehaviour
             rb.velocity = new Vector2(rb.velocity.normalized.x * 0.5f, rb.velocity.y);
         }
 
-        //Jump
-        if (Input.GetButtonDown("Jump") && isGround())
-        {
-            rb.AddForce(Vector2.up * JumpPower, ForceMode2D.Impulse);
-            isJump = true;
-            jumpCounter = 0;
-            anim.SetBool("Jump", true);
-        }
-
-        if (rb.velocity.y > 0 && isJump)
-        {
-            jumpCounter += Time.deltaTime;
-            if (jumpCounter > jumpTime) isJump = false;
-
-            float j_time = jumpCounter / jumpTime;
-            float currentJump = jumpMultiplier;
-
-            if(j_time > 0.5f)   // 점프 시간의 절반이 지나면 상승속도 줄어듬(유사관성)
-            {
-                currentJump = jumpMultiplier * (1 - j_time);
-            }
-
-            rb.velocity += vecGravity * jumpMultiplier * Time.deltaTime;
-        }
-
-        if (Input.GetButtonUp("Jump"))
-        {
-            isJump = false;
-            jumpCounter = 0; 
-
-            if (rb.velocity.y > 0)  //제일 약한 점프
-            {
-                rb.velocity = new Vector2(rb.velocity.x, rb.velocity.y * 0.5f);
-            }
-        }
-
-        if (rb.velocity.y < 0)  // 떨어질때 속도 증가
-        {
-            rb.velocity -= vecGravity * fallMultiplier * Time.deltaTime;
-            anim.SetBool("Jump", false);
-        }
-
-        //Attack
-        if(curTime <= 0)
-        {
-            if (Input.GetKeyDown(KeyCode.Z))
-            {
-
-                Collider2D[] collider2Ds = Physics2D.OverlapBoxAll(pos.position, boxSize, 0);
-                foreach (Collider2D collider in collider2Ds)
-                {
-                    if(CompareTag("Enemy"))
-                    {
-                        //collider.GetComponent<Enemy>().TakeDamage('데미지');
-                    }
-                }
-
-                anim.SetTrigger("Attack");
-                curTime = coolTime;
-            }
-        }
-        else
-        {
-            curTime -= Time.deltaTime;
-        }
+        Jump();
+        Attack();        
     }
 
     void FixedUpdate()
@@ -146,5 +84,93 @@ public class PlayerControler : MonoBehaviour
     {
         Gizmos.color = Color.red;
         Gizmos.DrawWireCube(pos.position, boxSize);
+        Gizmos.DrawWireCube(pos2.position, boxSize);
+    }
+
+    void Jump()
+    {
+        //Jump
+        if (Input.GetButtonDown("Jump") && isGround())
+        {
+            rb.AddForce(Vector2.up * JumpPower, ForceMode2D.Impulse);
+            isJump = true;
+            jumpCounter = 0;
+            anim.SetBool("Jump", true);
+        }
+
+        if (rb.velocity.y > 0 && isJump)
+        {
+            jumpCounter += Time.deltaTime;
+            if (jumpCounter > jumpTime) isJump = false;
+
+            float j_time = jumpCounter / jumpTime;
+            float currentJump = jumpMultiplier;
+
+            if (j_time > 0.5f)   // 점프 시간의 절반이 지나면 상승속도 줄어듬(유사관성)
+            {
+                currentJump = jumpMultiplier * (1 - j_time);
+            }
+
+            rb.velocity += vecGravity * jumpMultiplier * Time.deltaTime;
+        }
+
+        if (Input.GetButtonUp("Jump"))
+        {
+            isJump = false;
+            jumpCounter = 0;
+
+            if (rb.velocity.y > 0)  //제일 약한 점프
+            {
+                rb.velocity = new Vector2(rb.velocity.x, rb.velocity.y * 0.5f);
+            }
+        }
+
+        if (rb.velocity.y < 0)  // 떨어질때 속도 증가
+        {
+            rb.velocity -= vecGravity * fallMultiplier * Time.deltaTime;
+            anim.SetBool("Jump", false);
+        }
+    }
+
+    void Attack()
+    {
+        //Attack
+        if (curTime <= 0)
+        {
+            if (Input.GetKeyDown(KeyCode.Z))
+            {
+                if (!spriter.flipX)
+                {
+                    Collider2D[] collider2Ds = Physics2D.OverlapBoxAll(pos.position, boxSize, 0);
+                    foreach (Collider2D collider in collider2Ds)
+                    {
+                        if (collider.tag == "Enemy")
+                        {
+                            collider.GetComponent<Enemy>().TakeDamage(1);
+                        }
+                    }
+                }
+
+                else
+                {
+                    Collider2D[] collider2Ds = Physics2D.OverlapBoxAll(pos2.position, boxSize, 0);
+                    foreach (Collider2D collider in collider2Ds)
+                    {
+                        if (collider.tag == "Enemy")
+                        {
+                            collider.GetComponent<Enemy>().TakeDamage(1);
+                        }
+                    }
+                } 
+                
+
+                anim.SetTrigger("Attack");
+                curTime = coolTime;
+            }
+        }
+        else
+        {
+            curTime -= Time.deltaTime;
+        }
     }
 }


### PR DESCRIPTION
좌우로 움직이는 적과 맵 크기에 대한 카메라 이동을 구현했습니다.

# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다. 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요.

- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
달라진 기능에는 무엇이 있는지 목록으로 작성합니다. 이번 작업 내용을 통해 할 수 있는 기능 및 행동 등을 설명해주세요.

- 플레이어 공격에 의한 적 피격
- 적 간단한 이동 AI
- 맵 크기에 따른 카메라 이동 제한

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다. 어떤 코드 작성 혹은 패키지 혹은 인스펙터값 조정 등 실제 작업한 내용을 여기에 적으세요.

- 플레이어 공격에 의한 적 피격
> 플레이어의 근접 공격 레이어에 맞으면 태그를 체크해 적에게 피해를 입힙니다.
- 적 간단한 이동 AI
> 적은 랜덤한 시간에 따라 좌/우/정지 행동을 반복하며 낭떠러지를 탐지해 방향을 반전시킵니다.
- 맵 크기에 따른 카메라 이동 제한
> 벽 쪽에플레이어가 다가가면 카메라가 맵의 외곽을 비치지 않고 게임 화면만 비추게 됩니다. 

# 스크린샷
이 기능과 관련된 스크린샷을 추가합니다. (동영상 가능)
![esf](https://github.com/Gongju-Unity-Bootcamp/Noname/assets/148856359/82d2a8ce-cb2c-4e04-96f0-15a9c75dafde)
![image](https://github.com/Gongju-Unity-Bootcamp/Noname/assets/148856359/3961feb0-8901-4d01-8365-04671cd3f3cc)


# (선택)관련 이슈
이번 변경과 관련된 이슈가 있다면 아래에 작성해주세요.

- [x] #10 
---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요. 또 [여기](https://blog.banksalad.com/tech/banksalad-code-review-culture/)도 참고해보세요.

- [코드 컨벤션](https://learn.microsoft.com/ko-kr/dotnet/csharp/fundamentals/coding-style/coding-conventions)을 지키고 있는가?
- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
  - 불필요한 필드가 존재하진 않는가?
- 모듈화는 잘 되어 있는가?
    - 객체 간 결합도는 충분히 낮은가?
    - 함수는 하나의 일만 해결하고 있는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 버그가 날만한 곳은 없는가?
    - NullReferenceException이 발생할 만한 부분은 없는가?